### PR TITLE
fix(utils): make capitalize function upper case the first letter only

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -79,7 +79,7 @@ function generateUID() {
  * @returns {*}
  */
 function capitalize(string) {
-  return _.capitalize(string);
+  return _.upperFirst(string);
 }
 
 /**

--- a/src/core/text.js
+++ b/src/core/text.js
@@ -17,6 +17,7 @@ AttributeDictionary.addRule("text", "_textureSrc", {
   displayName: "Font Image Src",
   editor: "filepath"
 });
+
 AttributeDictionary.addRule("text", "_color", { displayName: "Color" });
 AttributeDictionary.addRule("text", "_text", { displayName: "Text" });
 AttributeDictionary.addRule("text", "_texture", { visible: false });
@@ -99,7 +100,7 @@ export default class Text extends GameObject {
 
   //#region Static Methods
 
-  static restore(data) {
+  static async restore(data) {
     let superRestore = super.restore(data);
 
     let text = new Text();
@@ -118,9 +119,7 @@ export default class Text extends GameObject {
     text.setDropShadowOffset(Vector2.restore(data.dropShadowOffset));
     text.setDebug(data.debug);
 
-    text.setTextureSrc(data.textureSrc);
-
-    return Objectify.extend(text, superRestore);
+    return Objectify.extend(await text.setTextureSrc(data.textureSrc), superRestore);
   }
 
   //#endregion


### PR DESCRIPTION
Just noticed that the previous capitalize function was just capitalizing the first letter of a given string, whereas [lodash capitalize](https://lodash.com/docs/4.17.4#capitalize) also lower cases the remaining string.

This was causing inspector getters and setters to not be found and thus not show the specified property editors (e.g., filepath).

Changed it to [lodash upperFirst](https://lodash.com/docs/4.17.4#upperFirst) which yields the same and desirable output as before.

Using lodash could be entirely avoided obviously, but reinventing the wheel isn't a good choice I would argue.